### PR TITLE
fix: serve get-zk0bot.sh on Jekyll site

### DIFF
--- a/build-site.sh
+++ b/build-site.sh
@@ -56,7 +56,8 @@ else
   # Re-copy root LICENSE and CONTRIBUTING.md after clean
   cp ../LICENSE ./ 2>/dev/null || echo "LICENSE copy failed (non-fatal)"
   cp ../CONTRIBUTING.md ./ 2>/dev/null || echo "CONTRIBUTING.md copy failed (non-fatal)"
-  ls -la LICENSE CONTRIBUTING.md || echo "Copied files verification failed"
+  cp ../get-zk0bot.sh ./ 2>/dev/null || echo "get-zk0bot.sh copy failed (non-fatal)"
+  ls -la LICENSE CONTRIBUTING.md get-zk0bot.sh || echo "Copied files verification failed"
 
   # Build with explicit source/destination
   bundle exec jekyll build --source . --destination ../_site --verbose

--- a/get-zk0bot.sh
+++ b/get-zk0bot.sh
@@ -1,3 +1,5 @@
+---
+---
 #!/bin/bash
 
 # zk0bot Installer


### PR DESCRIPTION
- Add Jekyll front matter to get-zk0bot.sh for site inclusion
- Update build-site.sh to copy get-zk0bot.sh in both build phases
- Jekyll now reads, renders, and writes get-zk0bot.sh to _site
- Enables https://zk0.bot/get-zk0bot.sh for one-line installer

Fixes website serving issue for shell script.