### PR TITLE
feat(website): add HICAM Austin Robotics presentation X post to Community Buzz

### DIFF
--- a/website/index.md
+++ b/website/index.md
@@ -92,6 +92,11 @@ pip install -e .
 
 <div class="social-posts">
   <h2>Community Buzz</h2>
+
+  <!-- Austin Robotics presentation at HICAM (photo post) -->
+  <blockquote class="twitter-tweet" data-media-max-width="560"><a href="https://twitter.com/ivelini/status/2016885550741852291"></a></blockquote>
+  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+
   <blockquote class="twitter-tweet"><p lang="en" dir="ltr">It's time for a complete open-source stack for autonomy/robotics plus distributed learning. The first step is here: <a href="https://twitter.com/LeRobotHF?ref_src=twsrc%5Etfw">@LeRobotHF</a> + <a href="https://twitter.com/flwrlabs?ref_src=twsrc%5Etfw">@flwrlabs</a> LFG 🚀<a href="https://twitter.com/comma_ai?ref_src=twsrc%5Etfw">@comma_ai</a> <a href="https://twitter.com/wayve_ai?ref_src=twsrc%5Etfw">@wayve_ai</a> <a href="https://twitter.com/Figure_robot?ref_src=twsrc%5Etfw">@Figure_robot</a> <a href="https://twitter.com/Tesla?ref_src=twsrc%5Etfw">@Tesla</a> <a href="https://t.co/8O8cSD3SbO">https://t.co/8O8cSD3SbO</a> <a href="https://t.co/oVUOLTvwzm">https://t.co/oVUOLTvwzm</a></p>&mdash; nic lane (@niclane7) <a href="https://twitter.com/niclane7/status/1879597539676266726?ref_src=twsrc%5Etfw">January 15, 2025</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
   <blockquote class="twitter-tweet"><p lang="en" dir="ltr">Open-source robots just got a boost. Frameworks like Flower FL enable faster learning, efficient scaling, and continuous knowledge sharing using real-world data. <a href="https://t.co/j8VSGiWF0W">https://t.co/j8VSGiWF0W</a></p>&mdash; 𝚐𝔪𝟾𝚡𝚡𝟾 (@gm8xx8) <a href="https://twitter.com/gm8xx8/status/1879633368427761785?ref_src=twsrc%5Etfw">January 15, 2025</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>


### PR DESCRIPTION
Adds a new entry to the Community Buzz section on the homepage featuring the X post with photos from the Austin Robotics presentation at HICAM.

**Post:** https://x.com/ivelini/status/2016885550741852291

- Uses the standard Twitter/X embed blockquote (with `data-media-max-width`) so the photo renders properly.
- Placed as the lead item in the grid for visibility of recent local events.
- Minimal change (only `website/index.md`).

Previewed locally before opening PR.